### PR TITLE
feat: Implement UUID generation for DataType and ValidationRule entities

### DIFF
--- a/src/main/java/sv/edu/udb/data_collector/controller/CatalogController.java
+++ b/src/main/java/sv/edu/udb/data_collector/controller/CatalogController.java
@@ -37,7 +37,7 @@ public class CatalogController {
     @PutMapping("/{catalogId}")
     public CatalogResponse update(@PathVariable String catalogId,
                                   @Valid @RequestBody CatalogUpdateRequest req) {
-        return catalogMapper.toResponse(service.updateCatalog(catalogId, req.getName(), req.getDescription()));
+        return catalogMapper.toResponse(service.updateCatalog(catalogId, req));
     }
 
     @DeleteMapping("/{catalogId}")

--- a/src/main/java/sv/edu/udb/data_collector/controller/request/CatalogCreateRequest.java
+++ b/src/main/java/sv/edu/udb/data_collector/controller/request/CatalogCreateRequest.java
@@ -7,7 +7,6 @@ import lombok.Data;
 public class CatalogCreateRequest {
     @NotBlank
     private String name;
-    @NotBlank
     private String description;
     @NotBlank
     private String workspaceId; 

--- a/src/main/java/sv/edu/udb/data_collector/controller/request/CatalogUpdateRequest.java
+++ b/src/main/java/sv/edu/udb/data_collector/controller/request/CatalogUpdateRequest.java
@@ -1,11 +1,9 @@
 package sv.edu.udb.data_collector.controller.request;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class CatalogUpdateRequest {
-    @NotBlank
     private String name;
     private String description;
 }

--- a/src/main/java/sv/edu/udb/data_collector/domain/Catalog.java
+++ b/src/main/java/sv/edu/udb/data_collector/domain/Catalog.java
@@ -27,7 +27,7 @@ public class Catalog {
     @Column(nullable = false, length = 120)
     private String name;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = true,columnDefinition = "TEXT")
     private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/sv/edu/udb/data_collector/domain/DataType.java
+++ b/src/main/java/sv/edu/udb/data_collector/domain/DataType.java
@@ -1,5 +1,7 @@
 package sv.edu.udb.data_collector.domain;
 
+import org.hibernate.annotations.UuidGenerator;
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,6 +12,8 @@ import lombok.*;
 public class DataType {
 
     @Id
+    @UuidGenerator // Genera UUIDs automáticamente (si prefieres String “cuid”, mira la nota abajo)
+    @Column(nullable = false, updatable = false, length = 36)
     private String id; // generado por el seed (UUID()), no por JPA
 
     @Column(nullable = false, unique = true, length = 50)

--- a/src/main/java/sv/edu/udb/data_collector/domain/ValidationRule.java
+++ b/src/main/java/sv/edu/udb/data_collector/domain/ValidationRule.java
@@ -1,5 +1,7 @@
 package sv.edu.udb.data_collector.domain;
 
+import org.hibernate.annotations.UuidGenerator;
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,8 +15,9 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class ValidationRule {
-
         @Id
+        @UuidGenerator // Genera UUIDs automáticamente (si prefieres String “cuid”, mira la nota abajo)
+        @Column(nullable = false, updatable = false, length = 36)
         private String id;
 
         @Column(nullable = false, unique = true, length = 191)

--- a/src/main/java/sv/edu/udb/data_collector/service/CatalogService.java
+++ b/src/main/java/sv/edu/udb/data_collector/service/CatalogService.java
@@ -1,5 +1,6 @@
 package sv.edu.udb.data_collector.service;
 
+import sv.edu.udb.data_collector.controller.request.CatalogUpdateRequest;
 import sv.edu.udb.data_collector.domain.Catalog;
 import sv.edu.udb.data_collector.domain.CatalogItem;
 
@@ -9,7 +10,7 @@ public interface CatalogService {
 
     // Catalog
     Catalog createCatalog(String workspaceId, String name, String description);
-    Catalog updateCatalog(String catalogId, String name, String description);
+    Catalog updateCatalog(String catalogId, CatalogUpdateRequest request);
     void deleteCatalog(String catalogId);
     Catalog getCatalog(String catalogId);
     List<Catalog> listCatalogs(String workspaceId); // si workspaceId es null, listar todos (según negocio)

--- a/src/main/java/sv/edu/udb/data_collector/service/implementation/CatalogServiceImpl.java
+++ b/src/main/java/sv/edu/udb/data_collector/service/implementation/CatalogServiceImpl.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.persistence.EntityNotFoundException;
+import sv.edu.udb.data_collector.controller.request.CatalogUpdateRequest;
 import sv.edu.udb.data_collector.domain.Catalog;
 import sv.edu.udb.data_collector.domain.CatalogItem;
 import sv.edu.udb.data_collector.domain.Workspace;
@@ -47,19 +50,30 @@ public class CatalogServiceImpl implements CatalogService {
     }
 
     @Override
-    public Catalog updateCatalog(String catalogId, String name, String description) {
+    @Transactional
+    public Catalog updateCatalog(String catalogId, CatalogUpdateRequest request) {
+        // 1. Obtenemos la entidad existente de la base de datos.
         Catalog catalog = catalogRepository.findById(catalogId)
-                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Catalog not found"));
+                .orElseThrow(() -> new EntityNotFoundException("Catalog not found with id: " + catalogId));
 
-        // validar unique name dentro del workspace (si aplica)
-        String wsId = catalog.getWorkspace() != null ? catalog.getWorkspace().getId() : null;
-        if (wsId != null && catalogRepository.existsByNameAndWorkspaceId(name, wsId)
-                && !catalog.getName().equalsIgnoreCase(name)) {
-            throw new ResponseStatusException(CONFLICT, "Catalog name already exists in this workspace");
+        // 2. Actualizamos el nombre solo si se proporcionó uno nuevo.
+        if (request.getName() != null && !request.getName().isBlank()) {
+            // Validamos que el nuevo nombre no cree un duplicado.
+            String wsId = catalog.getWorkspace().getId();
+            if (!catalog.getName().equalsIgnoreCase(request.getName()) &&
+                    catalogRepository.existsByNameAndWorkspaceId(request.getName(), wsId)) {
+
+                throw new IllegalStateException("Catalog name already exists in this workspace");
+            }
+            catalog.setName(request.getName());
         }
 
-        catalog.setName(name);
-        catalog.setDescription(description);
+        // 3. Actualizamos la descripción solo si se proporcionó una nueva.
+        if (request.getDescription() != null) {
+            catalog.setDescription(request.getDescription());
+        }
+
+        // 4. Guardamos la entidad con los cambios aplicados.
         return catalogRepository.save(catalog);
     }
 
@@ -82,7 +96,7 @@ public class CatalogServiceImpl implements CatalogService {
     public List<Catalog> listCatalogs(String workspaceId) {
         if (workspaceId == null || workspaceId.isBlank()) {
             return catalogRepository.findAll().stream()
-                    .sorted((a,b) -> a.getName().compareToIgnoreCase(b.getName()))
+                    .sorted((a, b) -> a.getName().compareToIgnoreCase(b.getName()))
                     .toList();
         }
         return catalogRepository.findAllByWorkspaceIdOrderByNameAsc(workspaceId);

--- a/src/main/resources/db/migration/V10__make_catalg_description_optional.sql
+++ b/src/main/resources/db/migration/V10__make_catalg_description_optional.sql
@@ -1,0 +1,1 @@
+ALTER TABLE catalogs MODIFY description TEXT NULL;

--- a/src/test/java/sv/edu/udb/data_collector/controller/CatalogControllerTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/controller/CatalogControllerTest.java
@@ -1,0 +1,148 @@
+package sv.edu.udb.data_collector.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import sv.edu.udb.data_collector.configuration.RestExceptionHandler;
+import sv.edu.udb.data_collector.controller.request.CatalogCreateRequest;
+import sv.edu.udb.data_collector.controller.request.CatalogItemCreateRequest;
+import sv.edu.udb.data_collector.controller.response.CatalogItemResponse;
+import sv.edu.udb.data_collector.controller.response.CatalogResponse;
+import sv.edu.udb.data_collector.domain.Catalog;
+import sv.edu.udb.data_collector.domain.CatalogItem;
+import sv.edu.udb.data_collector.domain.Workspace;
+import sv.edu.udb.data_collector.security.SecurityConfig;
+import sv.edu.udb.data_collector.security.jwt.JwtAuthenticationFilter;
+import sv.edu.udb.data_collector.service.CatalogService;
+import sv.edu.udb.data_collector.service.mapper.CatalogItemMapper;
+import sv.edu.udb.data_collector.service.mapper.CatalogMapper;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+
+@WebMvcTest(
+        controllers = CatalogController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        },
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = { SecurityConfig.class, JwtAuthenticationFilter.class }
+        )
+)
+@Import(RestExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CatalogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CatalogService service;
+
+    @MockBean
+    private CatalogMapper catalogMapper;
+
+    @MockBean
+    private CatalogItemMapper itemMapper;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Catalog catalogEntity;
+    private CatalogResponse catalogResponse;
+    private CatalogItem catalogItemEntity;
+    private CatalogItemResponse catalogItemResponse;
+
+    @BeforeEach
+    void setUp() {
+        // Arrange (preparación común)
+        Workspace workspace = Workspace.builder().id("ws-1").build();
+        catalogEntity = Catalog.builder().id("cat-1").name("Países").workspace(workspace).build();
+        catalogResponse = CatalogResponse.builder().id("cat-1").name("Países").workspaceId("ws-1").build();
+        
+        catalogItemEntity = CatalogItem.builder().id("item-1").value("El Salvador").catalog(catalogEntity).build();
+        catalogItemResponse = CatalogItemResponse.builder().id("item-1").value("El Salvador").catalogId("cat-1").build();
+    }
+
+    //--- Pruebas para los endpoints de Catalog ---
+
+    @Test
+    @DisplayName("Catalog: POST /api/catalogs - Debe crear un catálogo y devolver 201 Created")
+    void createCatalog_shouldReturnCreated() throws Exception {
+        // Arrange
+        CatalogCreateRequest request = new CatalogCreateRequest();
+        request.setName("Países");
+        request.setWorkspaceId("ws-1");
+
+        given(service.createCatalog(any(), any(), any())).willReturn(catalogEntity);
+        given(catalogMapper.toResponse(any(Catalog.class))).willReturn(catalogResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/catalogs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/catalogs/cat-1"))
+                .andExpect(jsonPath("$.id", is("cat-1")))
+                .andExpect(jsonPath("$.name", is("Países")));
+    }
+    
+    //--- Pruebas para los endpoints de CatalogItem ---
+
+    @Test
+    @DisplayName("CatalogItem: POST /api/catalogs/{id}/items - Debe crear un ítem y devolver 201 Created")
+    void createItem_shouldReturnCreated() throws Exception {
+        // Arrange
+        CatalogItemCreateRequest request = new CatalogItemCreateRequest();
+        request.setValue("El Salvador");
+
+        given(service.createItem(any(), any())).willReturn(catalogItemEntity);
+        given(itemMapper.toResponse(any(CatalogItem.class))).willReturn(catalogItemResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/catalogs/{catalogId}/items", "cat-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/catalogs/cat-1/items/item-1"))
+                .andExpect(jsonPath("$.id", is("item-1")));
+    }
+
+    @Test
+    @DisplayName("CatalogItem: DELETE /api/catalogs/{id}/items/{id} - Debe eliminar un ítem y devolver 204 No Content")
+    void deleteItem_shouldReturnNoContent() throws Exception {
+        // Arrange
+        // No se necesita `given` para métodos void
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/catalogs/{catalogId}/items/{itemId}", "cat-1", "item-1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/controller/ValidationRuleControllerTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/controller/ValidationRuleControllerTest.java
@@ -1,0 +1,124 @@
+package sv.edu.udb.data_collector.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import sv.edu.udb.data_collector.configuration.RestExceptionHandler;
+import sv.edu.udb.data_collector.controller.response.ValidationRuleResponse;
+import sv.edu.udb.data_collector.domain.ValidationRule;
+import sv.edu.udb.data_collector.security.SecurityConfig;
+import sv.edu.udb.data_collector.security.jwt.JwtAuthenticationFilter;
+import sv.edu.udb.data_collector.service.ValidationRuleService;
+import sv.edu.udb.data_collector.service.mapper.ValidationRuleMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+      controllers = ValidationRuleController.class,
+      excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        },
+      excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = { SecurityConfig.class, JwtAuthenticationFilter.class }
+        )
+) // Carga solo el contexto web para este controlador
+@Import(RestExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ValidationRuleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ValidationRuleService service;
+
+    @MockBean
+    private ValidationRuleMapper mapper;
+
+    private ValidationRule ruleEntity;
+    private ValidationRuleResponse ruleResponse;
+
+    @BeforeEach
+    void setUp() {
+        // Arrange (preparación común)
+        ruleEntity = ValidationRule.builder()
+                .id(UUID.randomUUID().toString())
+                .name("REQUIRED")
+                .build();
+
+        ruleResponse = ValidationRuleResponse.builder()
+                .id(ruleEntity.getId())
+                .name("REQUIRED")
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET /api/validation-rules - Debe devolver una lista de reglas y 200 OK")
+    void list_shouldReturnListOfRules() throws Exception {
+        // Arrange
+        List<ValidationRule> entityList = List.of(ruleEntity);
+        List<ValidationRuleResponse> responseList = List.of(ruleResponse);
+
+        given(service.findAll()).willReturn(entityList);
+        given(mapper.toResponseList(entityList)).willReturn(responseList);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/validation-rules"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name", is("REQUIRED")));
+    }
+
+    @Test
+    @DisplayName("GET /api/validation-rules/{id} - Debe devolver una regla por ID y 200 OK")
+    void get_whenFound_shouldReturnRule() throws Exception {
+        // Arrange
+        given(service.findById(ruleEntity.getId())).willReturn(ruleEntity);
+        given(mapper.toResponse(ruleEntity)).willReturn(ruleResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/validation-rules/{id}", ruleEntity.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(ruleEntity.getId())))
+                .andExpect(jsonPath("$.name", is("REQUIRED")));
+    }
+
+    @Test
+    @DisplayName("GET /api/validation-rules/{id} - Debe devolver 404 Not Found si la regla no existe")
+    void get_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Arrange
+        String nonExistentId = "id-que-no-existe";
+        given(service.findById(nonExistentId))
+                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Regla no encontrada"));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/validation-rules/{id}", nonExistentId))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/repository/CatalogItemRepositoryTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/repository/CatalogItemRepositoryTest.java
@@ -1,0 +1,96 @@
+package sv.edu.udb.data_collector.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import sv.edu.udb.data_collector.domain.Catalog;
+import sv.edu.udb.data_collector.domain.CatalogItem;
+import sv.edu.udb.data_collector.domain.Workspace;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class CatalogItemRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+    
+    @Autowired
+    private CatalogItemRepository catalogItemRepository;
+
+    private Catalog catalog1;
+    private Catalog catalog2;
+    private CatalogItem item1a;
+
+    @BeforeEach
+    void setUp() {
+        // Arrange
+        Workspace workspace = Workspace.builder().name("Mi Workspace").build();
+        entityManager.persist(workspace);
+
+        catalog1 = Catalog.builder().name("Países").workspace(workspace).build();
+        catalog2 = Catalog.builder().name("Monedas").workspace(workspace).build();
+        entityManager.persist(catalog1);
+        entityManager.persist(catalog2);
+
+        item1a = CatalogItem.builder().value("Guatemala").catalog(catalog1).build();
+        CatalogItem item1b = CatalogItem.builder().value("El Salvador").catalog(catalog1).build();
+        CatalogItem item1c = CatalogItem.builder().value("Honduras").catalog(catalog1).build();
+        CatalogItem item2a = CatalogItem.builder().value("USD").catalog(catalog2).build();
+
+        entityManager.persist(item1a);
+        entityManager.persist(item1b);
+        entityManager.persist(item1c);
+        entityManager.persist(item2a);
+        entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("Debe encontrar todos los ítems de un catálogo, ordenados por valor")
+    void findAllByCatalog_IdOrderByValue_shouldReturnOrderedItems() {
+        // Act
+        List<CatalogItem> items = catalogItemRepository.findAllByCatalog_IdOrderByValue(catalog1.getId());
+
+        // Assert
+        assertThat(items).hasSize(3);
+        assertThat(items).extracting(CatalogItem::getValue).containsExactly("El Salvador", "Guatemala", "Honduras");
+    }
+
+    @Test
+    @DisplayName("Debe encontrar un ítem por su ID y el ID de su catálogo")
+    void findByIdAndCatalog_Id_whenExists_shouldReturnItem() {
+        // Act
+        Optional<CatalogItem> foundItem = catalogItemRepository.findByIdAndCatalog_Id(item1a.getId(), catalog1.getId());
+        Optional<CatalogItem> notFoundItem = catalogItemRepository.findByIdAndCatalog_Id(item1a.getId(), catalog2.getId());
+
+        // Assert
+        assertThat(foundItem).isPresent();
+        assertThat(foundItem.get().getValue()).isEqualTo("Guatemala");
+        assertThat(notFoundItem).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("Debe verificar si un ítem existe por su valor y catálogo")
+    void existsByCatalogIdAndValue_shouldReturnCorrectBoolean() {
+        // Act
+        boolean shouldBeTrue = catalogItemRepository.existsByCatalogIdAndValue(catalog1.getId(), "El Salvador");
+        boolean shouldBeFalse_wrongValue = catalogItemRepository.existsByCatalogIdAndValue(catalog1.getId(), "México");
+        boolean shouldBeFalse_wrongCatalog = catalogItemRepository.existsByCatalogIdAndValue(catalog2.getId(), "El Salvador");
+
+        // Assert
+        assertThat(shouldBeTrue).isTrue();
+        assertThat(shouldBeFalse_wrongValue).isFalse();
+        assertThat(shouldBeFalse_wrongCatalog).isFalse();
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/repository/CatalogRepositoryTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/repository/CatalogRepositoryTest.java
@@ -1,0 +1,82 @@
+package sv.edu.udb.data_collector.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import sv.edu.udb.data_collector.domain.Catalog;
+import sv.edu.udb.data_collector.domain.Workspace;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class CatalogRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private CatalogRepository catalogRepository;
+
+    private Workspace workspace;
+    private Catalog catalog1;
+
+    @BeforeEach
+    void setUp() {
+        // Arrange
+        workspace = Workspace.builder().name("Mi Workspace").build();
+        entityManager.persist(workspace);
+
+        catalog1 = Catalog.builder().name("Países").workspace(workspace).build();
+        Catalog catalog2 = Catalog.builder().name("Monedas").workspace(workspace).build();
+        entityManager.persist(catalog1);
+        entityManager.persist(catalog2);
+        entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("Debe encontrar todos los catálogos de un workspace, ordenados por nombre")
+    void findAllByWorkspaceIdOrderByNameAsc_shouldReturnOrderedCatalogs() {
+        // Act
+        List<Catalog> catalogs = catalogRepository.findAllByWorkspaceIdOrderByNameAsc(workspace.getId());
+
+        // Assert
+        assertThat(catalogs).hasSize(2);
+        assertThat(catalogs).extracting(Catalog::getName).containsExactly("Monedas", "Países");
+    }
+
+    @Test
+    @DisplayName("Debe encontrar un catálogo por su ID y el ID de su workspace")
+    void findByIdAndWorkspaceId_whenExists_shouldReturnCatalog() {
+        // Act
+        Optional<Catalog> foundCatalog = catalogRepository.findByIdAndWorkspaceId(catalog1.getId(), workspace.getId());
+        Optional<Catalog> notFoundCatalog = catalogRepository.findByIdAndWorkspaceId(catalog1.getId(), "wrong-workspace-id");
+
+        // Assert
+        assertThat(foundCatalog).isPresent();
+        assertThat(foundCatalog.get().getName()).isEqualTo("Países");
+        assertThat(notFoundCatalog).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("Debe verificar si un catálogo existe por su nombre y workspace")
+    void existsByNameAndWorkspaceId_shouldReturnCorrectBoolean() {
+        // Act
+        boolean shouldBeTrue = catalogRepository.existsByNameAndWorkspaceId("Países", workspace.getId());
+        boolean shouldBeFalse = catalogRepository.existsByNameAndWorkspaceId("Ciudades", workspace.getId());
+
+        // Assert
+        assertThat(shouldBeTrue).isTrue();
+        assertThat(shouldBeFalse).isFalse();
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/repository/DataTypeRepositoryTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/repository/DataTypeRepositoryTest.java
@@ -32,10 +32,10 @@ class DataTypeRepositoryTest {
         // Creamos y guardamos un conjunto de datos de prueba.
         // El orden de persistencia es aleatorio para asegurar que el test
         // comprueba el ordenamiento del método del repositorio.
-        entityManager.persist(DataType.builder().id("dt-3").name("NUMBER").kind("number").build());
-        entityManager.persist(DataType.builder().id("dt-1").name("STRING").kind("string").build());
-        entityManager.persist(DataType.builder().id("dt-4").name("CATALOG").kind("catalog").build());
-        entityManager.persist(DataType.builder().id("dt-2").name("BOOLEAN").kind("boolean").build());
+        entityManager.persist(DataType.builder().name("NUMBER").kind("number").build());
+        entityManager.persist(DataType.builder().name("STRING").kind("string").build());
+        entityManager.persist(DataType.builder().name("CATALOG").kind("catalog").build());
+        entityManager.persist(DataType.builder().name("BOOLEAN").kind("boolean").build());
         
         entityManager.flush();
     }

--- a/src/test/java/sv/edu/udb/data_collector/repository/ValidationRuleRepositoryTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/repository/ValidationRuleRepositoryTest.java
@@ -1,0 +1,91 @@
+package sv.edu.udb.data_collector.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import sv.edu.udb.data_collector.domain.ValidationRule;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class ValidationRuleRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ValidationRuleRepository validationRuleRepository;
+
+    @BeforeEach
+    void setUp() {
+        // Arrange (preparación común)
+        ValidationRule rule1 = ValidationRule.builder().name("REQUIRED").build();
+        ValidationRule rule2 = ValidationRule.builder().name("MAX_LENGTH").build();
+        entityManager.persist(rule1);
+        entityManager.persist(rule2);
+        entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("Debe encontrar una regla por su nombre, ignorando mayúsculas/minúsculas")
+    void findByNameIgnoreCase_whenExists_shouldReturnRule() {
+        // Arrange
+        // Los datos ya fueron preparados en setUp()
+
+        // Act
+        Optional<ValidationRule> foundRule = validationRuleRepository.findByNameIgnoreCase("required"); // Búsqueda en minúsculas
+
+        // Assert
+        assertThat(foundRule).isPresent();
+        assertThat(foundRule.get().getName()).isEqualTo("REQUIRED");
+    }
+
+    @Test
+    @DisplayName("No debe encontrar una regla si el nombre no existe")
+    void findByNameIgnoreCase_whenDoesNotExist_shouldReturnEmpty() {
+        // Arrange
+        // Los datos ya fueron preparados
+
+        // Act
+        Optional<ValidationRule> notFoundRule = validationRuleRepository.findByNameIgnoreCase("non_existent_rule");
+
+        // Assert
+        assertThat(notFoundRule).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("Debe devolver true si una regla existe, ignorando mayúsculas/minúsculas")
+    void existsByNameIgnoreCase_whenExists_shouldReturnTrue() {
+        // Arrange
+        // Los datos ya fueron preparados
+
+        // Act
+        boolean exists = validationRuleRepository.existsByNameIgnoreCase("max_length"); // Búsqueda en minúsculas
+
+        // Assert
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("Debe devolver false si una regla no existe")
+    void existsByNameIgnoreCase_whenDoesNotExist_shouldReturnFalse() {
+        // Arrange
+        // Los datos ya fueron preparados
+
+        // Act
+        boolean exists = validationRuleRepository.existsByNameIgnoreCase("non_existent_rule");
+
+        // Assert
+        assertThat(exists).isFalse();
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/service/CatalogServiceImplTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/service/CatalogServiceImplTest.java
@@ -1,0 +1,154 @@
+package sv.edu.udb.data_collector.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+import sv.edu.udb.data_collector.domain.Catalog;
+import sv.edu.udb.data_collector.domain.CatalogItem;
+import sv.edu.udb.data_collector.domain.Workspace;
+import sv.edu.udb.data_collector.repository.CatalogItemRepository;
+import sv.edu.udb.data_collector.repository.CatalogRepository;
+import sv.edu.udb.data_collector.repository.WorkspaceRepository;
+import sv.edu.udb.data_collector.service.implementation.CatalogServiceImpl;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogServiceImplTest {
+
+    @Mock
+    private CatalogRepository catalogRepository;
+    @Mock
+    private CatalogItemRepository itemRepository;
+    @Mock
+    private WorkspaceRepository workspaceRepository;
+
+    @InjectMocks
+    private CatalogServiceImpl catalogService;
+
+    private Workspace workspace;
+    private Catalog catalog;
+    private CatalogItem catalogItem;
+
+    @BeforeEach
+    void setUp() {
+        workspace = Workspace.builder().id("ws-1").name("Test Workspace").build();
+        catalog = Catalog.builder().id("cat-1").name("Países").workspace(workspace).build();
+        catalogItem = CatalogItem.builder().id("item-1").value("El Salvador").catalog(catalog).build();
+    }
+    
+    // --- Pruebas para la gestión de Catálogos ---
+    @Nested
+    @DisplayName("Pruebas de Catálogos")
+    class CatalogTests {
+        @Test
+        @DisplayName("Debe crear un catálogo exitosamente")
+        void createCatalog_whenDataIsValid_shouldSucceed() {
+            // Arrange
+            given(workspaceRepository.findById("ws-1")).willReturn(Optional.of(workspace));
+            given(catalogRepository.existsByNameAndWorkspaceId("Nuevo Catálogo", "ws-1")).willReturn(false);
+            given(catalogRepository.save(any(Catalog.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // Act
+            Catalog result = catalogService.createCatalog("ws-1", "Nuevo Catálogo", "Descripción");
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getName()).isEqualTo("Nuevo Catálogo");
+            assertThat(result.getWorkspace().getId()).isEqualTo("ws-1");
+            verify(catalogRepository).save(any(Catalog.class));
+        }
+
+        @Test
+        @DisplayName("Debe lanzar excepción si el nombre del catálogo ya existe en el workspace")
+        void createCatalog_whenNameExists_shouldThrowException() {
+            // Arrange
+            given(workspaceRepository.findById("ws-1")).willReturn(Optional.of(workspace));
+            given(catalogRepository.existsByNameAndWorkspaceId("Nombre Repetido", "ws-1")).willReturn(true);
+
+            // Act & Assert
+            assertThrows(ResponseStatusException.class, () -> {
+                catalogService.createCatalog("ws-1", "Nombre Repetido", "Desc");
+            });
+        }
+    }
+
+    // --- Pruebas para la gestión de Ítems de Catálogo ---
+    @Nested
+    @DisplayName("Pruebas de Ítems de Catálogo")
+    class CatalogItemTests {
+        @Test
+        @DisplayName("Debe crear un ítem de catálogo exitosamente")
+        void createItem_whenDataIsValid_shouldSucceed() {
+            // Arrange
+            given(catalogRepository.findById("cat-1")).willReturn(Optional.of(catalog));
+            given(itemRepository.existsByCatalogIdAndValue("cat-1", "Nuevo Valor")).willReturn(false);
+            given(itemRepository.save(any(CatalogItem.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // Act
+            CatalogItem result = catalogService.createItem("cat-1", "Nuevo Valor");
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getValue()).isEqualTo("Nuevo Valor");
+            assertThat(result.getCatalog().getId()).isEqualTo("cat-1");
+            verify(itemRepository).save(any(CatalogItem.class));
+        }
+
+        @Test
+        @DisplayName("Debe actualizar un ítem de catálogo exitosamente")
+        void updateItem_whenDataIsValid_shouldSucceed() {
+            // Arrange
+            given(itemRepository.findByIdAndCatalog_Id("item-1", "cat-1")).willReturn(Optional.of(catalogItem));
+            given(itemRepository.existsByCatalogIdAndValue("cat-1", "Valor Actualizado")).willReturn(false);
+            given(itemRepository.save(any(CatalogItem.class))).willReturn(catalogItem);
+
+            // Act
+            CatalogItem result = catalogService.updateItem("cat-1", "item-1", "Valor Actualizado");
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getValue()).isEqualTo("Valor Actualizado");
+            verify(itemRepository).save(catalogItem);
+        }
+
+        @Test
+        @DisplayName("Debe lanzar excepción al actualizar si el nuevo valor ya existe")
+        void updateItem_whenValueExists_shouldThrowException() {
+            // Arrange
+            given(itemRepository.findByIdAndCatalog_Id("item-1", "cat-1")).willReturn(Optional.of(catalogItem));
+            given(itemRepository.existsByCatalogIdAndValue("cat-1", "Valor Duplicado")).willReturn(true);
+
+            // Act & Assert
+            assertThrows(ResponseStatusException.class, () -> {
+                catalogService.updateItem("cat-1", "item-1", "Valor Duplicado");
+            });
+        }
+
+        @Test
+        @DisplayName("Debe eliminar un ítem de catálogo")
+        void deleteItem_shouldSucceed() {
+            // Arrange
+            given(itemRepository.findByIdAndCatalog_Id("item-1", "cat-1")).willReturn(Optional.of(catalogItem));
+            doNothing().when(itemRepository).delete(catalogItem);
+
+            // Act
+            catalogService.deleteItem("cat-1", "item-1");
+
+            // Assert
+            verify(itemRepository, times(1)).delete(catalogItem);
+        }
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/service/ValidationRuleServiceImplTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/service/ValidationRuleServiceImplTest.java
@@ -1,0 +1,87 @@
+package sv.edu.udb.data_collector.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+import sv.edu.udb.data_collector.domain.ValidationRule;
+import sv.edu.udb.data_collector.repository.ValidationRuleRepository;
+import sv.edu.udb.data_collector.service.implementation.ValidationRuleServiceImpl;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ValidationRuleServiceImplTest {
+
+    @Mock
+    private ValidationRuleRepository repository;
+
+    @InjectMocks
+    private ValidationRuleServiceImpl validationRuleService;
+
+    private ValidationRule rule1;
+    private ValidationRule rule2;
+
+    @BeforeEach
+    void setUp() {
+        // Arrange (preparación común)
+        rule1 = ValidationRule.builder().id(UUID.randomUUID().toString()).name("REQUIRED").build();
+        rule2 = ValidationRule.builder().id(UUID.randomUUID().toString()).name("MAX_LENGTH").build();
+    }
+
+    @Test
+    @DisplayName("Debe devolver todas las reglas de validación")
+    void findAll_shouldReturnAllRules() {
+        // Arrange
+        given(repository.findAll()).willReturn(List.of(rule1, rule2));
+
+        // Act
+        List<ValidationRule> result = validationRuleService.findAll();
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+        verify(repository).findAll();
+    }
+
+    @Test
+    @DisplayName("Debe devolver una regla de validación por su ID cuando existe")
+    void findById_whenFound_shouldReturnRule() {
+        // Arrange
+        given(repository.findById(rule1.getId())).willReturn(Optional.of(rule1));
+
+        // Act
+        ValidationRule result = validationRuleService.findById(rule1.getId());
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(rule1.getId());
+        verify(repository).findById(rule1.getId());
+    }
+
+    @Test
+    @DisplayName("Debe lanzar ResponseStatusException si la regla no se encuentra por su ID")
+    void findById_whenNotFound_shouldThrowException() {
+        // Arrange
+        String nonExistentId = "id-que-no-existe";
+        given(repository.findById(nonExistentId)).willReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResponseStatusException.class, () -> {
+            validationRuleService.findById(nonExistentId);
+        });
+        
+        verify(repository).findById(nonExistentId);
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/service/mapper/CatalogItemMapperTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/service/mapper/CatalogItemMapperTest.java
@@ -1,0 +1,46 @@
+package sv.edu.udb.data_collector.service.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import sv.edu.udb.data_collector.controller.response.CatalogItemResponse;
+import sv.edu.udb.data_collector.domain.Catalog;
+import sv.edu.udb.data_collector.domain.CatalogItem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogItemMapperTest {
+
+    private final CatalogItemMapper mapper = Mappers.getMapper(CatalogItemMapper.class);
+
+    @Test
+    @DisplayName("Debe mapear una entidad CatalogItem a un CatalogItemResponse correctamente")
+    void shouldMapCatalogItemToResponse() {
+        // Arrange
+        Catalog catalog = Catalog.builder().id("cat-1").build();
+        CatalogItem entity = CatalogItem.builder()
+                .id("item-1")
+                .value("El Salvador")
+                .catalog(catalog)
+                .build();
+
+        // Act
+        CatalogItemResponse response = mapper.toResponse(entity);
+
+        // Assert
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo("item-1");
+        assertThat(response.getValue()).isEqualTo("El Salvador");
+        assertThat(response.getCatalogId()).isEqualTo("cat-1");
+    }
+
+    @Test
+    @DisplayName("Debe devolver nulo si la entidad CatalogItem de entrada es nula")
+    void shouldReturnNullWhenCatalogItemIsNull() {
+        // Act
+        CatalogItemResponse response = mapper.toResponse(null);
+
+        // Assert
+        assertThat(response).isNull();
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/service/mapper/CatalogMapperTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/service/mapper/CatalogMapperTest.java
@@ -1,0 +1,48 @@
+package sv.edu.udb.data_collector.service.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import sv.edu.udb.data_collector.controller.response.CatalogResponse;
+import sv.edu.udb.data_collector.domain.Catalog;
+import sv.edu.udb.data_collector.domain.Workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogMapperTest {
+
+    private final CatalogMapper mapper = Mappers.getMapper(CatalogMapper.class);
+
+    @Test
+    @DisplayName("Debe mapear una entidad Catalog a un CatalogResponse correctamente")
+    void shouldMapCatalogToResponse() {
+        // Arrange
+        Workspace workspace = Workspace.builder().id("ws-1").build();
+        Catalog entity = Catalog.builder()
+                .id("cat-1")
+                .name("Países")
+                .description("Lista de países")
+                .workspace(workspace)
+                .build();
+
+        // Act
+        CatalogResponse response = mapper.toResponse(entity);
+
+        // Assert
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo("cat-1");
+        assertThat(response.getName()).isEqualTo("Países");
+        assertThat(response.getDescription()).isEqualTo("Lista de países");
+        assertThat(response.getWorkspaceId()).isEqualTo("ws-1");
+    }
+
+    @Test
+    @DisplayName("Debe devolver nulo si la entidad Catalog de entrada es nula")
+    void shouldReturnNullWhenCatalogIsNull() {
+        // Act
+        CatalogResponse response = mapper.toResponse(null);
+
+        // Assert
+        assertThat(response).isNull();
+    }
+}

--- a/src/test/java/sv/edu/udb/data_collector/service/mapper/ValidationRuleMapperTest.java
+++ b/src/test/java/sv/edu/udb/data_collector/service/mapper/ValidationRuleMapperTest.java
@@ -1,0 +1,66 @@
+package sv.edu.udb.data_collector.service.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import sv.edu.udb.data_collector.controller.response.ValidationRuleResponse;
+import sv.edu.udb.data_collector.domain.ValidationRule;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ValidationRuleMapperTest {
+
+    // Obtenemos una instancia del mapper que MapStruct generó
+    private final ValidationRuleMapper mapper = Mappers.getMapper(ValidationRuleMapper.class);
+
+    @Test
+    @DisplayName("Debe mapear una entidad ValidationRule a un ValidationRuleResponse correctamente")
+    void shouldMapValidationRuleToResponse() {
+        // Arrange (Organizar)
+        // Creamos una entidad de prueba reflejando el nuevo diseño
+        ValidationRule entity = ValidationRule.builder()
+                .name("Required")
+                .build();
+
+        // Act (Actuar)
+        ValidationRuleResponse response = mapper.toResponse(entity);
+
+        // Assert (Afirmar)
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(entity.getId());
+        assertThat(response.getName()).isEqualTo("Required");
+    }
+
+    @Test
+    @DisplayName("Debe devolver nulo si la entidad de entrada es nula")
+    void shouldReturnNullWhenEntityIsNull() {
+        // Arrange
+        ValidationRule entity = null;
+        
+        // Act
+        ValidationRuleResponse response = mapper.toResponse(entity);
+        
+        // Assert
+        assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("Debe mapear una lista de entidades a una lista de respuestas")
+    void shouldMapEntityListToResponseList() {
+        // Arrange
+        ValidationRule entity1 = ValidationRule.builder().name("Required").build();
+        ValidationRule entity2 = ValidationRule.builder().name("Max Length").build();
+        List<ValidationRule> entityList = List.of(entity1, entity2);
+        
+        // Act
+        List<ValidationRuleResponse> responseList = mapper.toResponseList(entityList);
+        
+        // Assert
+        assertThat(responseList).isNotNull();
+        assertThat(responseList).hasSize(2);
+        assertThat(responseList.get(0).getId()).isEqualTo(entity1.getId());
+        assertThat(responseList.get(1).getName()).isEqualTo("Max Length");
+    }
+}


### PR DESCRIPTION
- Added @UuidGenerator annotation to the id fields in DataType and ValidationRule classes to automatically generate UUIDs.
- Updated CatalogService to accept a CatalogUpdateRequest object for updating catalogs, improving method signature clarity.
- Refactored CatalogServiceImpl to handle catalog updates more robustly, including validation for unique catalog names within a workspace.
- Removed deprecated validation rules from the database migration script.
- Created new migration script to make catalog description optional.
- Added comprehensive unit tests for CatalogController, ValidationRuleController, and various repository and service classes to ensure functionality and correctness.
- Implemented mappers for converting between domain entities and response DTOs, with corresponding unit tests to validate mapping logic.